### PR TITLE
greater ease for comparing pre and post australis via filters

### DIFF
--- a/filter-post.json
+++ b/filter-post.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "dimensions": [
+    {
+      "field_name": "reason",
+      "allowed_values": ["saved-session"]
+    },
+    {
+      "field_name": "appName",
+      "allowed_values": ["Firefox"]
+    },
+    {
+      "field_name": "appUpdateChannel",
+      "allowed_values": ["beta", "aurora"]
+    },
+    {
+      "field_name": "appVersion",
+      "allowed_values": {
+        "min": "29.0",
+        "max": "29.999"
+      }
+    },
+    {
+      "field_name": "appBuildID",
+      "allowed_values": {
+        "min": "20140208004002",
+        "max": "99999999999999"
+      }
+    },
+    {
+      "field_name": "submission_date",
+      "allowed_values": {
+        "min": "20140203",
+        "max": "20140321"
+      }
+    }
+  ]
+}

--- a/filter-pre.json
+++ b/filter-pre.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "dimensions": [
+    {
+      "field_name": "reason",
+      "allowed_values": ["saved-session"]
+    },
+    {
+      "field_name": "appName",
+      "allowed_values": ["Firefox"]
+    },
+    {
+      "field_name": "appUpdateChannel",
+      "allowed_values": ["beta", "aurora", "release"]
+    },
+    {
+      "field_name": "appVersion",
+      "allowed_values": {
+        "min": "28.0",
+        "max": "28.999"
+      }
+    },
+    {
+      "field_name": "appBuildID",
+      "allowed_values": {
+        "min": "20140123004002",
+        "max": "99999999999999"
+      }
+    },
+    {
+      "field_name": "submission_date",
+      "allowed_values": {
+        "min": "20140203",
+        "max": "20140321"
+      }
+    }
+  ]
+}

--- a/run.sh
+++ b/run.sh
@@ -14,16 +14,17 @@ fi
 # Parse the arguments, kinda.
 while [[ $1 ]]; do
   case $1 in
-    -f|--for-real)
-      FILTER="filter.json"
+    --filter)
+      shift
+      FILTER=$1
       ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS]"
-      echo "  -f, --for-real        Use the less-specific non-test filter."
       echo "  -h, --help            Show this help."
       echo "  -m, --map-reduce ARG  Specify which mapreduce file to use."
       echo "  -p, --pull-data       Force the program to skip the cache, and pull the data again."
       echo "  -v, --verbose         Show more info about what's happening'."
+      echo "  --filter              Use specified filter."
       exit 0
       ;;
     -m|--map-reduce)

--- a/uitour.py
+++ b/uitour.py
@@ -25,13 +25,12 @@ def map(k, d, v, cx):
     countableEventBuckets = []
     customizeBuckets = []
 
-    prefix = "post::"
+    prefix = ""
     cx.write(prefix+ "instances", 1)
 
 
     if "toolbars" in ui:
         toolbars = ui["toolbars"]
-
         countableDefaultEvents = toolbars["countableEvents"].get("__DEFAULT__", {})
         feature_measures = {}
         #note: simple swaps kept in "kept"


### PR DESCRIPTION
NOW with easier pre/post Australis flavor!

Specify name of the filter file (filter-pre.json or filter.post.json) as an argument to --filter, and get the results for that query. NOTE: must move results from a query before performing another or they will be overwritten.
